### PR TITLE
Unload Assests and speed up loading

### DIFF
--- a/SongLoaderPlugin/CustomSongInfo.cs
+++ b/SongLoaderPlugin/CustomSongInfo.cs
@@ -5,7 +5,7 @@ using System.Security.Cryptography;
 namespace SongLoaderPlugin
 {
 	[Serializable]
-	public class CustomSongInfo
+	public class CustomSongInfo : IEquatable<CustomSongInfo>
 	{
 		public string songName;
 		public string songSubName;
@@ -48,5 +48,10 @@ namespace SongLoaderPlugin
 			levelId = hash + "∎" + string.Join("∎", new[] {songName, songSubName, authorName, beatsPerMinute.ToString()}) + "∎";
 			return levelId;
 		}
-	}
+
+        public bool Equals(CustomSongInfo other)
+        {
+            return levelId == other.levelId;
+        }
+    }
 }

--- a/SongLoaderPlugin/SongLoader.cs
+++ b/SongLoaderPlugin/SongLoader.cs
@@ -76,7 +76,14 @@ namespace SongLoaderPlugin
             }
         }
 
+        // Parameterless call to not break other mods
         public void RefreshSongs()
+        {
+            RefreshSongs(false);
+        }
+
+        // New Refresh to specify if should reload ALL songs, or just new ones
+        public void RefreshSongs(bool fullRefresh = false)
         {
             if (SceneManager.GetActiveScene().buildIndex != MenuIndex) return;
             Log("Refreshing songs");
@@ -88,13 +95,19 @@ namespace SongLoaderPlugin
             var gameDataModel = PersistentSingleton<GameDataModel>.instance;
             var oldData = gameDataModel.gameStaticData.worldsData[0].levelsData.ToList();
 
-            foreach (var customSongInfo in CustomSongInfos)
+            if (fullRefresh)
             {
-                oldData.RemoveAll(x => x.levelId == customSongInfo.levelId);
+                Log("Unloading old songs.");
+                foreach (var customSongInfo in CustomSongInfos)
+                {
+                    oldData.RemoveAll(x => x.levelId == customSongInfo.levelId);
+                }
+
+                CustomLevelStaticDatas.Clear();
+                CustomSongInfos.Clear();
             }
 
-            CustomLevelStaticDatas.Clear();
-            CustomSongInfos.Clear();
+            Resources.UnloadUnusedAssets();
 
             foreach (var song in songs)
             {
@@ -104,6 +117,13 @@ namespace SongLoaderPlugin
                     Log("Duplicate song found at " + song.path);
                     continue;
                 }
+
+                if (CustomSongInfos.Any(x => x.levelId == song.levelId))
+                {
+                    //Log("Song already loaded: "+ song.songName);
+                    continue;
+                }
+                //Log("New song found: " + song.songName);
 
                 CustomSongInfos.Add(song);
 
@@ -356,7 +376,7 @@ namespace SongLoaderPlugin
         {
             if (Input.GetKeyDown(KeyCode.R))
             {
-                RefreshSongs();
+                RefreshSongs(true);
             }
         }
     }


### PR DESCRIPTION
Unloads old song resources on refresh (No more increasing RAM usage)
Only loads new songs when returning from BeatSaver menu (Speeding up load time)
Pressing 'r' on the main menu still does a full refresh

Known Issues:
Doesn't take redownloaded songs into account on refresh