### PR TITLE
Force Difficulty Rank to Difficulty

### DIFF
--- a/SongLoaderPlugin/CustomSongInfo.cs
+++ b/SongLoaderPlugin/CustomSongInfo.cs
@@ -35,6 +35,7 @@ namespace SongLoaderPlugin
 			var combinedJson = "";
 			foreach (var diffLevel in difficultyLevels)
 			{
+                diffLevel.difficultyRank = (int)Enum.Parse(typeof(LevelStaticData.Difficulty), diffLevel.difficulty);
 				if (!File.Exists(path + "/" + diffLevel.jsonPath))
 				{
 					continue;


### PR DESCRIPTION
BeatSaberEditor does not enforce rank to difficulty

added line to force the rank to difficulty by overriding what is taken from the JSON.

List is now properly ordered in game