### PR TITLE
Zip file extraction to specific folder fix

### DIFF
--- a/SongLoaderPlugin/SongLoader.cs
+++ b/SongLoaderPlugin/SongLoader.cs
@@ -405,7 +405,8 @@ namespace SongLoaderPlugin
 									try 
 									{
 										Directory.CreateDirectory(dir);
-										using (FileStream f = File.Create(Path.Combine(dir, Path.GetFileName(entry.Name))))  {
+										using (FileStream f = File.Create(Path.Combine(dir, Path.GetFileName(entry.Name))))
+										{
 											unzip.Extract(entry.Name, f);
 										}
 									} catch { }

--- a/SongLoaderPlugin/SongLoader.cs
+++ b/SongLoaderPlugin/SongLoader.cs
@@ -397,9 +397,20 @@ namespace SongLoaderPlugin
 							currentHashes.Add(hash);
 							if (cachedSongs.Any(x => x.Contains(hash))) continue;
 
-							using (var unzip = new Unzip(songZip))
+							using (var unzip = new Unzip(songZip)) 
 							{
-								unzip.ExtractToDirectory(path + "/CustomSongs/.cache/" + hash);
+								string dir = path + "/CustomSongs/.cache/" + hash;
+								foreach (Unzip.Entry entry in unzip.Entries) 
+								{
+									try 
+									{
+										Directory.CreateDirectory(dir);
+										using (FileStream f = File.Create(Path.Combine(dir, Path.GetFileName(entry.Name))))  {
+											unzip.Extract(entry.Name, f);
+										}
+									} catch { }
+								}
+								//unzip.ExtractToDirectory(path + "/CustomSongs/.cache/" + hash);
 							}
 						}
 						else


### PR DESCRIPTION
It makes sure the files are in the hash folder in .cache without creating an additional folder
It dosent fix that special characters are still broken in the Unzip library