### PR TITLE
ChromaToggle Detection

### DIFF
--- a/SongLoaderPlugin/CustomSongInfo.cs
+++ b/SongLoaderPlugin/CustomSongInfo.cs
@@ -38,6 +38,7 @@ namespace SongLoaderPlugin
 			public string jsonPath;
 			public string json;
 			public float noteJumpMovementSpeed;
+            public bool chromaToggle;
 		}
 
 		public string GetIdentifier()

--- a/SongLoaderPlugin/CustomSongInfo.cs
+++ b/SongLoaderPlugin/CustomSongInfo.cs
@@ -38,7 +38,7 @@ namespace SongLoaderPlugin
 			public string jsonPath;
 			public string json;
 			public float noteJumpMovementSpeed;
-            public bool chromaToggle;
+            public bool chromaToggle = false;
 		}
 
 		public string GetIdentifier()

--- a/SongLoaderPlugin/SongLoader.cs
+++ b/SongLoaderPlugin/SongLoader.cs
@@ -657,7 +657,7 @@ namespace SongLoaderPlugin
                         }
                         catch (Exception)
                         {
-                            Log(string.Format("Level {0} on Difficulty {1} is ChromaToggle enabled, but ChromaToggle was not detected. Skipping...", n["songName"], difficulty.ToString()));
+                            Log(string.Format("Level {0} on Difficulty {1} is ChromaToggle enabled, but ChromaToggle was not detected. Skipping...", songInfo.songName, difficulty.ToString()));
                             continue;
                         }
                     }

--- a/SongLoaderPlugin/SongLoader.cs
+++ b/SongLoaderPlugin/SongLoader.cs
@@ -545,7 +545,10 @@ namespace SongLoaderPlugin
 					}
 					else
 					{
-						_standardLevelCollection.LevelList.Add(customLevel);
+                        if (customLevel.customSongInfo.difficultyLevels.Where((CustomSongInfo.DifficultyLevel x) => x.chromaToggle).Count() == 0)
+                            _standardLevelCollection.LevelList.Add(customLevel);
+                        else
+                            Log(string.Format("Level {0} includes a ChromaToggle map. It will not be added to the Standard Level Collection.", customLevel.songName));
 						_noArrowsLevelCollection.LevelList.Add(customLevel);
 						_partyLevelCollection.LevelList.Add(customLevel);
 					}
@@ -673,7 +676,8 @@ namespace SongLoaderPlugin
 					difficultyRank = difficultyRank,
 					audioPath = n["audioPath"],
 					jsonPath = n["jsonPath"],
-					noteJumpMovementSpeed = n["noteJumpMovementSpeed"]
+					noteJumpMovementSpeed = n["noteJumpMovementSpeed"],
+                    chromaToggle = n["chromaToggle"] == "On"
 				});
 			}
 

--- a/SongLoaderPlugin/SongLoader.cs
+++ b/SongLoaderPlugin/SongLoader.cs
@@ -546,11 +546,30 @@ namespace SongLoaderPlugin
 					else
 					{
                         if (customLevel.customSongInfo.difficultyLevels.Where((CustomSongInfo.DifficultyLevel x) => x.chromaToggle).Count() == 0)
+                        {
                             _standardLevelCollection.LevelList.Add(customLevel);
+                            _noArrowsLevelCollection.LevelList.Add(customLevel);
+                            _partyLevelCollection.LevelList.Add(customLevel);
+                        }
                         else
-                            Log(string.Format("Level {0} includes a ChromaToggle map. It will not be added to the Standard Level Collection.", customLevel.songName));
-						_noArrowsLevelCollection.LevelList.Add(customLevel);
-						_partyLevelCollection.LevelList.Add(customLevel);
+                        {
+                            try
+                            {
+                                Log(string.Format("Level {0} includes a ChromaToggle map. ChromaToggle maps will be filtered from the Standard Level Collection.", customLevel.songName));
+                                CustomSongInfo info = customLevel.customSongInfo;
+                                info.songAuthorName += " <color=#00FFFF>(ChromaToggle Enabled!)</color>";
+                                _partyLevelCollection.LevelList.Add(LoadSong(info));
+                                CustomSongInfo filteredSong = LoadSong(info).customSongInfo;
+                                filteredSong.difficultyLevels = customLevel.customSongInfo.difficultyLevels.Where((CustomSongInfo.DifficultyLevel x) => !x.chromaToggle).ToArray();
+                                filteredSong.songAuthorName = filteredSong.songAuthorName.Substring(0, filteredSong.songAuthorName.IndexOf('<')) + " <color=#FF0000>(Filtered)</color>";
+                                _standardLevelCollection.LevelList.Add(LoadSong(filteredSong));
+                                _noArrowsLevelCollection.LevelList.Add(LoadSong(filteredSong));
+                            }
+                            catch (Exception e)
+                            {
+                                Log(e.ToString(), LogSeverity.Error);
+                            }
+                        }
 					}
 				}
 
@@ -648,27 +667,18 @@ namespace SongLoaderPlugin
 				var difficultyRank = (int)difficulty;
 
                 //(Attempts) to detect ChromaToggle maps when skips the map when ChromaToggle isnt detected
-                try
+                if (n["chromaToggle"] == "On")
                 {
-                    if (n["chromaToggle"] == "On")
-                    {
-                        try
-                        {//If for some reason it fails getting ChromaToggle, it errors. If it gets ChromaToggle but its null, throw an error. Same result!
-                            if (ChromaToggle.Plugin.mainSettingsModel == null)
-                                throw new Exception();
-                            else
-                                songInfo.authorName += " <color=#00FFFF>(ChromaToggle Enabled!)</color>";
-                        }
-                        catch (Exception)
-                        {
-                            Log(string.Format("Level {0} on Difficulty {1} is ChromaToggle enabled, but ChromaToggle was not detected. Skipping...", songInfo.songName, difficulty.ToString()));
-                            continue;
-                        }
+                    try
+                    {//If for some reason it fails getting ChromaToggle, it errors. If it gets ChromaToggle but its null, throw an error. Same result!
+                        if (ChromaToggle.Plugin.mainSettingsModel == null)
+                            throw new Exception();
                     }
-                }
-                catch (Exception e)
-                {
-                    Log(e.ToString());
+                    catch (Exception)
+                    {
+                        Log(string.Format("Level {0} on Difficulty {1} is ChromaToggle enabled, but ChromaToggle was not detected. Skipping...", songInfo.songName, difficulty.ToString()));
+                        continue;
+                    }
                 }
 
                 diffLevels.Add(new CustomSongInfo.DifficultyLevel

--- a/SongLoaderPlugin/SongLoader.cs
+++ b/SongLoaderPlugin/SongLoader.cs
@@ -635,7 +635,6 @@ namespace SongLoaderPlugin
 				Log("Error parsing song: " + songPath, LogSeverity.Warn);
 				return null;
 			}
-
 			songInfo.path = songPath;
 
 			//Here comes SimpleJSON to the rescue when JSONUtility can't handle an array.
@@ -657,6 +656,8 @@ namespace SongLoaderPlugin
                         {//If for some reason it fails getting ChromaToggle, it errors. If it gets ChromaToggle but its null, throw an error. Same result!
                             if (ChromaToggle.Plugin.mainSettingsModel == null)
                                 throw new Exception();
+                            else
+                                songInfo.authorName += " <color=#00FFFF>(ChromaToggle Enabled!)</color>";
                         }
                         catch (Exception)
                         {

--- a/SongLoaderPlugin/SongLoader.cs
+++ b/SongLoaderPlugin/SongLoader.cs
@@ -644,8 +644,30 @@ namespace SongLoaderPlugin
 				n = diffs[i];
 				var difficulty = Utils.ToEnum(n["difficulty"], LevelDifficulty.Normal);
 				var difficultyRank = (int)difficulty;
-				
-				diffLevels.Add(new CustomSongInfo.DifficultyLevel
+
+                //(Attempts) to detect ChromaToggle maps when skips the map when ChromaToggle isnt detected
+                try
+                {
+                    if (n["chromaToggle"] == "On")
+                    {
+                        try
+                        {//If for some reason it fails getting ChromaToggle, it errors. If it gets ChromaToggle but its null, throw an error. Same result!
+                            if (ChromaToggle.Plugin.mainSettingsModel == null)
+                                throw new Exception();
+                        }
+                        catch (Exception)
+                        {
+                            Log(string.Format("Level {0} on Difficulty {1} is ChromaToggle enabled, but ChromaToggle was not detected. Skipping...", n["songName"], difficulty.ToString()));
+                            continue;
+                        }
+                    }
+                }
+                catch (Exception e)
+                {
+                    Log(e.ToString());
+                }
+
+                diffLevels.Add(new CustomSongInfo.DifficultyLevel
 				{
 					difficulty = n["difficulty"],
 					difficultyRank = difficultyRank,

--- a/SongLoaderPlugin/SongLoaderPlugin.csproj
+++ b/SongLoaderPlugin/SongLoaderPlugin.csproj
@@ -36,6 +36,10 @@
     <Reference Include="Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null">
       <HintPath>D:\SteamLibrary\steamapps\common\Beat Saber\Beat Saber_Data\Managed\Assembly-CSharp.dll</HintPath>
     </Reference>
+    <Reference Include="ChromaToggle, Version=0.4.0.0, Culture=neutral, processorArchitecture=AMD64">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>D:\Oculus\Software\Software\hyperbolic-magnetism-beat-saber\Plugins\ChromaToggle.dll</HintPath>
+    </Reference>
     <Reference Include="IllusionPlugin, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null">
       <HintPath>..\..\IPA\IllusionPlugin\bin\Release\IllusionPlugin.dll</HintPath>
     </Reference>


### PR DESCRIPTION
<img src="https://media.discordapp.net/attachments/488923582370545666/495813199481012224/unknown.png" alt="uh oh this shouldnt be here i am bad with computer" class="inline"/>

I added ChromaToggle detection in `GetCustomSongInfo` for any difficultyLevel object that have the `chromaToggle` option set to `On`.

Due to how ChromaToggle uses bombs inside of notes to determine what type they are (0 = Normal, 1 = Alternate, 2 = Gray), people without ChromaToggle will pretty much fail in any map designed for ChromaToggle.

This solves the issue by checking whether or not the difficultyLevel has `chromaToggle` as described before, then checks to see if SongLoader can detect ChromaToggle's `MainSettingsModel`. If it cannot, it skips that difficulty option.

This also allows songs to have one difficulty made for ChromaToggle and one difficulty made without it, and players without ChromaToggle can play the difficulties made without the use of the plugin.