### PR TITLE
Remove direct call to OnTransitionDidFinish

### DIFF
--- a/SongLoaderPlugin/SceneEvents.cs
+++ b/SongLoaderPlugin/SceneEvents.cs
@@ -39,7 +39,6 @@ namespace SongLoaderPlugin
 				if (_gameScenesManager == null) return;
 
 				_gameScenesManager.transitionDidFinishEvent += GameScenesManagerOnTransitionDidFinishEvent;
-				GameScenesManagerOnTransitionDidFinishEvent();
 			}
 		}
 


### PR DESCRIPTION
`OnTransitionDidFinishEvent` is already raised in the finish callback of the `ScenesTransitionCoroutine`, thus making the direct call unnecessary.
This fixes the "Loading cancelled. Press Ctrl+R to refresh" error when launching the game.