### PR TITLE
Resolve conflict with Custom Platforms

### DIFF
--- a/SongLoaderPlugin/EnvironmentsLoader.cs
+++ b/SongLoaderPlugin/EnvironmentsLoader.cs
@@ -12,10 +12,10 @@ namespace SongLoaderPlugin
 		
 		public static SceneInfo GetSceneInfo(string environmentName)
 		{
-			var sceneInfo = SceneInfos.FirstOrDefault(x => x.sceneName == environmentName);
+			var sceneInfo = SceneInfos.FirstOrDefault(x => x.name == environmentName + "SceneInfo");
 			if (sceneInfo != null) return sceneInfo;
 
-			sceneInfo = Resources.FindObjectsOfTypeAll<SceneInfo>().FirstOrDefault(x => x.sceneName == environmentName);
+			sceneInfo = Resources.FindObjectsOfTypeAll<SceneInfo>().FirstOrDefault(x => x.name == environmentName + "SceneInfo");
 			if (sceneInfo == null)
 			{
 				Console.WriteLine("Failed to find scene info " + environmentName);


### PR DESCRIPTION
Resolve conflict with Custom Platforms' Environment Override system
Access SongInfos by name rather than content (sceneName)