### PR TITLE
Fix "loading cancelled" issue

### DIFF
--- a/SongLoaderPlugin/SongLoader.cs
+++ b/SongLoaderPlugin/SongLoader.cs
@@ -77,7 +77,7 @@ namespace SongLoaderPlugin
 
 		private void SceneManagerOnActiveSceneChanged(Scene arg0, Scene scene)
 		{
-			if (AreSongsLoading)
+			if (AreSongsLoading && activeScene.name != MenuSceneName)
 			{
 				//Scene changing while songs are loading. Since we are using a separate thread while loading, this is bad and could cause a crash.
 				//So we have to stop loading.


### PR DESCRIPTION
No more CTRL+R on first launch
Submitted on behalf of lolPants